### PR TITLE
Fix crash when inserting nil as KVC value

### DIFF
--- a/NSObject+Motis.m
+++ b/NSObject+Motis.m
@@ -270,7 +270,9 @@ static Class classFromString(NSString *string)
     if (originalValue == value && validated)
         validated = [self mts_validateAutomaticallyValue:&value forKey:mappedKey];
     
-    if (validated)
+    // The mts_validateAutomaticallyValue returns YES for nil, but while at some places it might be valid, here it's causing a crash
+    // You can't set a value to nil is KVC!
+    if (validated && value != nil)
     {
         [self setValue:value forKey:mappedKey];
     }


### PR DESCRIPTION
When mapping the values, Motis' validator returns that nil is valid (and it might be the case somewhere) but when you are calling setValue:forKey: value can't be nil, so in this case we have to check for that too. If it gets through as nil it's simply going to crash the app.
