### PR TITLE
Avoid setting values when equal

### DIFF
--- a/NSObject+Motis.h
+++ b/NSObject+Motis.h
@@ -56,6 +56,15 @@
  **/
 - (void)mts_setValuesForKeysWithDictionary:(NSDictionary *)dictionary;
 
+/**
+ * Whether or not Motis should, before assigning a value to a key,
+ * first get that value and compare it with the value-to-set using
+ * [NSObject isEqual:]. By default, this is `NO`.
+ * @param key The key of the attribute.
+ * @discussion This can be useful when using Motis with Core Data, because Core Data will flag `NSManagedObject` instances as updated, triggering database work, even if no properties have meaningfully changed.
+ **/
+- (BOOL)mts_checkKeyForEqualityBeforeAssignment:(NSString *)key;
+
 /** ---------------------------------------------- **
  * @name Key-Mapping Getters
  ** ---------------------------------------------- **/

--- a/NSObject+Motis.h
+++ b/NSObject+Motis.h
@@ -167,6 +167,7 @@
  *  - `-mts_ignoredSetValue:forUndefinedMappingKey`: If undefined keys are disabled (`mts_motisShouldSetUndefinedKeys`), this method will be called when a undefined mapping key is found.
  *  - `-mts_invalidValue:forKey:error:`: If value is does not pass valiation, this method is called after aborting the value setting.
  *  - `-mts_invalidValue:forArrayKey:error:`: if an array item does not pass validation, this method is called after aborting the item setting.
+ *  - `-mts_checkValueOfKeyForEqualityBeforeAssignment:`: if Motis should avoid calling `-setValue:forKey:` when `-isEqual:` is true.
  **/
 @interface NSObject (Motis_Subclassing)
 
@@ -182,7 +183,7 @@
 + (NSDictionary*)mts_mapping;
 
 /**
- 
+
  * Returns whether Motis should set keys not found in the mapping. Default value is `NO`. However, if no mapping is defined this method is ignored and Motis will attempt to set values for any key.
  * @return `YES` if Motis should set undefined mapping keys, `NO` if only the keys defined `+mts_mapping` can be set.
  * @discussion Subclasses may override to return `YES`. Remember that when setting values for undefined keys KVC will rise an exception which you can remove by overriding the KVC method `-setValue:forUndefinedKey:.

--- a/NSObject+Motis.h
+++ b/NSObject+Motis.h
@@ -56,15 +56,6 @@
  **/
 - (void)mts_setValuesForKeysWithDictionary:(NSDictionary *)dictionary;
 
-/**
- * Whether or not Motis should, before assigning a value to a key,
- * first get that value and compare it with the value-to-set using
- * [NSObject isEqual:]. By default, this is `NO`.
- * @param key The key of the attribute.
- * @discussion This can be useful when using Motis with Core Data, because Core Data will flag `NSManagedObject` instances as updated, triggering database work, even if no properties have meaningfully changed.
- **/
-- (BOOL)mts_checkKeyForEqualityBeforeAssignment:(NSString *)key;
-
 /** ---------------------------------------------- **
  * @name Key-Mapping Getters
  ** ---------------------------------------------- **/
@@ -283,5 +274,14 @@
  * @param error The validation error.
  **/
 - (void)mts_invalidValue:(id)value forArrayKey:(NSString *)key error:(NSError*)error;
+
+/**
+ * Whether or not Motis should, before assigning a value to a key,
+ * first get that value and compare it with the value-to-set using
+ * [NSObject isEqual:]. By default, this is `NO`.
+ * @param key The key of the attribute.
+ * @discussion This can be useful when using Motis with Core Data, because Core Data will flag `NSManagedObject` instances as updated, triggering database work, even if no properties have meaningfully changed.
+ **/
+- (BOOL)mts_checkValueOfKeyForEqualityBeforeAssignment:(NSString *)key;
 
 @end

--- a/NSObject+Motis.m
+++ b/NSObject+Motis.m
@@ -232,7 +232,11 @@ static Class classFromString(NSString *string)
     
     if (validated)
     {
-        [self setValue:value forKey:mappedKey];
+        if (![self mts_checkKeyForEqualityBeforeAssignment:mappedKey]
+            || ![[self mts_valueForKey:key] isEqual:value])
+        {
+            [self setValue:value forKey:mappedKey];
+        }
     }
     else
         [self mts_invalidValue:value forKey:mappedKey error:error];
@@ -421,6 +425,12 @@ static Class classFromString(NSString *string)
 {
     // Subclasses might override.
     MJLog(@"Item for ArrayKey <%@> is not valid in class %@. Error: %@", key, [self.class description], error);
+}
+
+- (BOOL)mts_checkKeyForEqualityBeforeAssignment:(NSString *)key
+{
+    // Subclasses might override.
+    return NO;
 }
 
 @end

--- a/NSObject+Motis.m
+++ b/NSObject+Motis.m
@@ -232,7 +232,7 @@ static Class classFromString(NSString *string)
     
     if (validated)
     {
-        if (![self mts_checkKeyForEqualityBeforeAssignment:mappedKey]
+        if (![self mts_checkValueOfKeyForEqualityBeforeAssignment:mappedKey]
             || ![[self mts_valueForKey:key] isEqual:value])
         {
             [self setValue:value forKey:mappedKey];
@@ -427,7 +427,7 @@ static Class classFromString(NSString *string)
     MJLog(@"Item for ArrayKey <%@> is not valid in class %@. Error: %@", key, [self.class description], error);
 }
 
-- (BOOL)mts_checkKeyForEqualityBeforeAssignment:(NSString *)key
+- (BOOL)mts_checkValueOfKeyForEqualityBeforeAssignment:(NSString *)key
 {
     // Subclasses might override.
     return NO;


### PR DESCRIPTION
In some cases, it’s useful to avoid calling setters when the values are known to be equal. In particular, calling a setter on an NSManagedObject will flag that object as updated in the context, which will trigger a database write, even if `[newValue isEqual:oldValue]`.

This adds an optional `-mts_checkValueOfKeyForEqualityBeforeAssignment:`.