### PR TITLE
Adding fixed array index property mapping

### DIFF
--- a/NSObject+Motis.m
+++ b/NSObject+Motis.m
@@ -329,11 +329,17 @@ static Class classFromString(NSString *string)
                 // For each keyPath component
                 
                 NSString *path = keyPath.components[i];
-                value = [value valueForKey:path];
+                // check if path is an index in an array
+                NSInteger index = [path integerValue];
+                if ((index > 0 || [path isEqualToString:@"0"]) && [value isKindOfClass:NSArray.class]) {
+                    value = [((NSArray *) value) objectAtIndex:index];
+                } else {
+                    value = [value valueForKey:path];
+                }
                 
                 if (i < count - 1)
                 {
-                    if (![value isKindOfClass:NSDictionary.class]) // <-- Checking that the KeyPath is only accessing dictionary objects.
+                    if (![value isKindOfClass:NSDictionary.class] && ![value isKindOfClass:NSArray.class])
                         break;
                 }
                 else

--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ For example, if receiving the following JSON:
                      "ranking" : 12,
                    },
     "user_avatars": [{
+      "avatar_type": "standard",
       "image_url": "http://www.avatars.com/john.doe"
+    }, {
+      "avatar_type": "large",
+      "image_url": "http://www.avatars.com/john.doe/large"
     }]
   }
 }

--- a/README.md
+++ b/README.md
@@ -51,12 +51,15 @@ For example, if receiving the following JSON:
   {
     "user_name" : "john.doe",
     "user_id" : 42,
-    "creation_date" :  "1979-11-07 17:23:51"
-    "webiste" : "http://www.domain.com"
+    "creation_date" :  "1979-11-07 17:23:51",
+    "webiste" : "http://www.domain.com",
     "user_stats" : {
                      "views" : 431,
                      "ranking" : 12,
-                   }
+                   },
+    "user_avatars": [{
+      "image_url": "http://www.avatars.com/john.doe"
+    }]
   }
 }
 ```
@@ -75,6 +78,7 @@ Then, in our `User` class entity (`NSObject` subclass) we would define the `+mts
 @property (nonatomic, strong) NSURL *website;
 @property (nonatomic, assing) NSInteger views;
 @property (nonatomic, assing) NSInteger ranking;
+@property (nonatomic, assing) NSURL *avatar;
 
 @end
 
@@ -90,13 +94,14 @@ Then, in our `User` class entity (`NSObject` subclass) we would define the `+mts
              @"website": mts_key(website),
              @"user_stats.views": mts_key(views),  // <-- KeyPath access
              @"user_stats.ranking": mts_key(ranking), // <-- KeyPath access
+             @"user_avatars.0.image_url": mts_key(avatar) // <-- KeyPath access using array index
             };
 }
 
 @end
 ```
 
-As shown in the example above, KeyPath access is supported to reference JSON content of dictionaries.
+As shown in the example above, KeyPath access is supported to reference JSON content of dictionaries. KeyPath access supports array index lookups when you need to map values into properties using a fixed array index.
 
 Also, as you might see, we are specifying custom types as `NSDate` or `NSURL`. Motis automatically attempt to convert JSON values to the object defined types. Check below for more information on automatic validation.
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ Then, in our `User` class entity (`NSObject` subclass) we would define the `+mts
 @property (nonatomic, assign) NSIntger userId;
 @property (nonatomic, strong) NSDate *creationDate;
 @property (nonatomic, strong) NSURL *website;
-@property (nonatomic, assing) NSInteger views;
-@property (nonatomic, assing) NSInteger ranking;
-@property (nonatomic, assing) NSURL *avatar;
+@property (nonatomic, assign) NSInteger views;
+@property (nonatomic, assign) NSInteger ranking;
+@property (nonatomic, assign) NSURL *avatar;
 
 @end
 

--- a/SampleProject/Motis Tests/Hierarchy Test/MJChildC.h
+++ b/SampleProject/Motis Tests/Hierarchy Test/MJChildC.h
@@ -1,0 +1,14 @@
+//
+//  MJChildC.h
+//  Motis
+//
+//  Created by Finkel, Michael on 7/8/15.
+//  Copyright (c) 2015 Mobile Jazz. All rights reserved.
+//
+
+#import "MJParentObject.h"
+
+@interface MJChildC : MJParentObject
+@property (nonatomic, assign) BOOL boolField;
+@property (nonatomic, strong) NSString *customField;
+@end

--- a/SampleProject/Motis Tests/Hierarchy Test/MJChildC.m
+++ b/SampleProject/Motis Tests/Hierarchy Test/MJChildC.m
@@ -1,0 +1,14 @@
+#import "MJChildC.h"
+
+#import "Motis.h"
+
+@implementation MJChildC
+
++ (NSDictionary*)mts_mapping
+{
+    return @{@"obj.0.bool": mts_key(boolField),
+             @"obj.1.field": mts_key(customField),
+             };
+}
+
+@end

--- a/SampleProject/Motis Tests/MJHierarchyTest.m
+++ b/SampleProject/Motis Tests/MJHierarchyTest.m
@@ -12,6 +12,7 @@
 
 #import "MJChildA.h"
 #import "MJChildB.h"
+#import "MJChildC.h"
 
 @interface MJHierarchyTest : XCTestCase
 
@@ -22,6 +23,7 @@
     MJParentObject *_parent;
     MJChildA *_childA;
     MJChildB *_childB;
+    MJChildC *_childC;
 }
 
 - (void)setUp
@@ -31,6 +33,7 @@
     _parent = [[MJParentObject alloc] init];
     _childA = [[MJChildA alloc] init];
     _childB = [[MJChildB alloc] init];
+    _childC = [[MJChildC alloc] init];
 }
 
 - (void)tearDown
@@ -57,6 +60,19 @@
     
     if (_childB.integerField != 7 || _childB.customField.count != 2)
         XCTFail(@"Incorrect values in Child B");
+    
 }
+
+- (void)testArrayIndexKeyPath {
+    NSDictionary *dictC = @{@"obj":@[@{@"bool": @YES}, @{@"field": @"Hello World"}]};
+    _childC.boolField = NO;
+    _childC.customField = nil;
+    [_childC mts_setValuesForKeysWithDictionary:dictC];
+    XCTAssert(_childC.boolField, @"Incorrect value for childC.boolField");
+    XCTAssertEqualObjects(@"Hello World", _childC.customField, @"Incorrect value for childC.customField");
+
+}
+
+
 
 @end

--- a/SampleProject/Motis.xcodeproj/project.pbxproj
+++ b/SampleProject/Motis.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5279FDDD1B4D9C79003D2E58 /* MJChildC.m in Sources */ = {isa = PBXBuildFile; fileRef = 5279FDDC1B4D9C79003D2E58 /* MJChildC.m */; };
 		D21D6FB218D7470D000E620B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D21D6FB018D7470D000E620B /* InfoPlist.strings */; };
 		D21D6FB518D74717000E620B /* NSObject+Motis.m in Sources */ = {isa = PBXBuildFile; fileRef = D21D6FB418D74717000E620B /* NSObject+Motis.m */; };
 		D259644819017D670055799F /* Twitter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D259644719017D670055799F /* Twitter.framework */; };
@@ -51,6 +52,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5279FDDB1B4D9C79003D2E58 /* MJChildC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MJChildC.h; path = "Hierarchy Test/MJChildC.h"; sourceTree = "<group>"; };
+		5279FDDC1B4D9C79003D2E58 /* MJChildC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MJChildC.m; path = "Hierarchy Test/MJChildC.m"; sourceTree = "<group>"; };
 		8758B81E18FD289C00666680 /* Motis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Motis.h; path = ../../Motis.h; sourceTree = "<group>"; };
 		D21D6FB118D7470D000E620B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = InfoPlist.strings; sourceTree = "<group>"; };
 		D21D6FB318D74717000E620B /* NSObject+Motis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSObject+Motis.h"; path = "../../NSObject+Motis.h"; sourceTree = "<group>"; };
@@ -283,6 +286,8 @@
 				D2E3E037190E8DBF002BD141 /* MJChildA.m */,
 				D2E3E039190E8DCA002BD141 /* MJChildB.h */,
 				D2E3E03A190E8DCA002BD141 /* MJChildB.m */,
+				5279FDDB1B4D9C79003D2E58 /* MJChildC.h */,
+				5279FDDC1B4D9C79003D2E58 /* MJChildC.m */,
 			);
 			name = "Hierarchy Test";
 			sourceTree = "<group>";
@@ -387,6 +392,7 @@
 				D2DD9FD5192DF28400163C50 /* MJMotisObjectWithFormatter.m in Sources */,
 				D2C890251A0ABC2900E81A9D /* MJParser.m in Sources */,
 				D2A0544E18D8A5B80050DE68 /* MJValidationTest.m in Sources */,
+				5279FDDD1B4D9C79003D2E58 /* MJChildC.m in Sources */,
 				D2C890271A0ABC2900E81A9D /* MJProject.m in Sources */,
 				D2E3E03B190E8DCA002BD141 /* MJChildB.m in Sources */,
 				D2C890231A0ABC2900E81A9D /* MJCompany.m in Sources */,


### PR DESCRIPTION
I've encountered a few different scenarios where it's clumsy to create object classes as wrappers for elements in a JSON array when I'm only going to use one or two properties from a specific item in that array. I thought it'd be great if you could reference the array index directly in the keyPath string. 

With this pull request you can use an array index as part of the keyPath string. Given a structure like 

```json
{"obj": [{
  "someKey": "someValue"
},{
  "someKey": "anotherValue"
}]}
```

you could now get `someValue` into a property on your root object like this:

```objective-c 
@interface SomeObject : NSObject

@property (nonatomic, strong) NSString *myval;

@end

@implementation SomeObject

+ (NSDictionary *)mts_mapping
{
  return @{@"obj.0.someKey": mts_key(myval)};
}
@end
```

Previously you'd have to create a new object and use that with `mts_arrayClassMapping` along with some additional code to pull the value into `SomeObject.myval`.