### PR TITLE
Remove backspace character

### DIFF
--- a/MTSMotisObject.h
+++ b/MTSMotisObject.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 
 /**
- * This class is a helper that allow to use NSCoding and NSCopying reusing the Motis mapping definitions.
+ * This class is a helper that allow to use NSCoding and NSCopying reusing the Motis mapping definitions.
  * This behavior will only apply to properties defined inside a Motis mapping (`+mts_mapping`).
  *
  * NOTE: This class is not needed to perform JSON mapping.The category NSObject+Motis can do it on any NSObject.


### PR DESCRIPTION
Xcode 7 keeps crashing when we are editing code that use MTSMotisObject, because there is invalid backspace character in comment block.

```
Application Specific Information:
ProductBuildVersion: 7B1005
ASSERTION FAILURE in /Library/Caches/com.apple.xbs/Sources/IDEPlugins/IDEPlugins-9057/IDEQuickHelp/Controllers/IDEQuickHelpController.m:360
Details:  Error creating XML document from clang-parsed comment block: Error Domain=NSXMLParserErrorDomain Code=9 "Line 2: PCDATA invalid Char value 8
" UserInfo={NSLocalizedDescription=Line 2: PCDATA invalid Char value 8
}
Object:   <IDEQuickHelpInspectorController: 0x7fe7187a7e50>
Method:   -generateHTMLForSymbol:fromQueryDictionary:inExpressionSource:context:
Thread:   <NSThread: 0x7fe712d19bc0>{number = 1, name = main}
Hints:   None
Backtrace:
  0  0x0000000106780d56 -[IDEAssertionHandler handleFailureInMethod:object:fileName:lineNumber:assertionSignature:messageFormat:arguments:] (in IDEKit)
```

![mtsmotisobject_h_ _search_results_____b___and_multi-file_search](https://cloud.githubusercontent.com/assets/96502/11144546/ac2c1698-89fd-11e5-968b-d44ce8b0ec69.png)

