### PR TITLE
Add option to preserve mutability when setting value to NSMutableArray properties

### DIFF
--- a/NSObject+Motis.m
+++ b/NSObject+Motis.m
@@ -1030,11 +1030,8 @@ static void mts_motisInitialization()
 - (BOOL)mts_validateAutomaticallyValue:(inout __autoreleasing id *)ioValue toClass:(Class)typeClass forKey:(NSString*)key
 {
     // If types match, just return
-    if ([*ioValue isKindOfClass:typeClass])
+    if ([*ioValue isKindOfClass:typeClass] && ![*ioValue isKindOfClass:NSArray.class])
     {
-        if ([*ioValue isKindOfClass:NSArray.class])
-            [self mts_validateArrayContent:ioValue forArrayKey:key];
-        
         return YES;
     }
     
@@ -1157,6 +1154,7 @@ static void mts_motisInitialization()
             *ioValue = [NSOrderedSet orderedSetWithArray:*ioValue];
             return *ioValue != nil;
         }
+        return *ioValue != nil;
     }
     else if ([*ioValue isKindOfClass:NSDictionary.class]) // <-- DICTIONARIES
     {


### PR DESCRIPTION
How to replicate problem?
1) Create Motis object with NSMutableArray property
2) Set values with mts_setValuesForKeysWithDictionary
3) In mts_validateAutomaticallyValue:toClass:forKey: array is parsed in first lines, in `if ([*ioValue isKindOfClass:typeClass])` statement with `return YES` at the end.

Now arrays are not parsed at the beginning, they go to the existing `if/else` statement where mutability is properly checked.